### PR TITLE
Handle arbitrary comments before translations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    polint (0.1.0)
+    polint (0.2.1)
       parslet (~> 1.7, >= 1.7.1)
       term-ansicolor
 

--- a/lib/polint.rb
+++ b/lib/polint.rb
@@ -120,7 +120,7 @@ module Polint
       tree = Polint::Parser.new.parse(data)
       tree = Polint::Transform.new.apply(tree)
 
-      die 'No Plural-Forms header found' unless tree[:headers].key?('Plural-Forms')
+      die "The PO file '#{@pofile}' has no Plural-Forms header, aborting." unless tree[:headers].key?('Plural-Forms')
       nplurals = tree[:headers]['Plural-Forms'][:nplurals]
 
       tree[:translations].each do |translation|
@@ -150,7 +150,7 @@ module Polint
         end
       end
     rescue Parslet::ParseFailed => e
-      die e.cause.ascii_tree
+      die "The PO file '#{@pofile}' cannot be parsed, aborting.\n\n#{e.cause.ascii_tree}"
     end
 
     # Check for errors in a key/translation pair.

--- a/lib/polint/parser.rb
+++ b/lib/polint/parser.rb
@@ -33,7 +33,8 @@ module Polint
     rule(:flag) { str(',') >> lwsp >> match(/[a-z\-]/).repeat(1).as(:flag) >> lwsp }
     rule(:flag_comment) { start_comment >> flag.repeat(1).as(:flags) >> endl }
     rule(:reference_comment) { start_comment >> str(':') >> lwsp >> match(/[^\n]/).repeat.as(:reference) >> endl }
-    rule(:comment) { flag_comment | reference_comment }
+    rule(:unparsed_comment) { start_comment >> lwsp >> match(/[^\n]/).repeat.as(:comment) >> endl }
+    rule(:comment) { flag_comment | reference_comment | unparsed_comment }
     rule(:comments) { comment.repeat }
 
     rule(:msgid) { str('msgid') >> lwsp >> quoted_strings.as(:msgid) }

--- a/lib/polint/parser.rb
+++ b/lib/polint/parser.rb
@@ -33,7 +33,7 @@ module Polint
     rule(:flag) { str(',') >> lwsp >> match(/[a-z\-]/).repeat(1).as(:flag) >> lwsp }
     rule(:flag_comment) { start_comment >> flag.repeat(1).as(:flags) >> endl }
     rule(:reference_comment) { start_comment >> str(':') >> lwsp >> match(/[^\n]/).repeat.as(:reference) >> endl }
-    rule(:unparsed_comment) { start_comment >> lwsp >> match(/[^\n]/).repeat.as(:comment) >> endl }
+    rule(:unparsed_comment) { start_comment >> (match(/[^~]/) >> lwsp >> match(/[^\n]/).repeat).as(:comment) >> endl }
     rule(:comment) { flag_comment | reference_comment | unparsed_comment }
     rule(:comments) { comment.repeat }
 
@@ -46,7 +46,11 @@ module Polint
     rule(:translation) { (comments >> msgid >> msgid_plural.maybe >> msgstr.repeat(1)).as(:translation) >> blank_line }
     rule(:translations) { translation.repeat }
 
-    rule(:file) { (headers >> translations).as(:file) }
+    rule(:obsolete_line) { start_comment >> str('~') >> lwsp >> match(/[^\n]/).repeat >> endl }
+    rule(:obsolete_translation) { obsolete_line.repeat(1).as(:obsolete_translation) >> blank_line }
+    rule(:obsolete_translations) { obsolete_translation.repeat }
+
+    rule(:file) { (headers >> translations >> obsolete_translations).as(:file) }
     root(:file)
 
   end

--- a/lib/polint/transform.rb
+++ b/lib/polint/transform.rb
@@ -16,12 +16,12 @@ module Polint
       { headers: items.to_h }
     end
 
-    rule(msgid: sequence(:items)) { { msgid: { text: items.join("\n") } } }
-    rule(msgid_plural: sequence(:items)) { { msgid_plural: { text: items.join("\n") } } }
+    rule(msgid: sequence(:items)) { { msgid: { text: items.join } } }
+    rule(msgid_plural: sequence(:items)) { { msgid_plural: { text: items.join } } }
     rule(msgstr: subtree(:items)) do
       msgstr = {}
       msgstr[:index] = items.shift[:index].to_i if items.first.is_a?(Hash)
-      msgstr[:text] = items.join("\n")
+      msgstr[:text] = items.join
       { msgstr: msgstr }
     end
 
@@ -29,6 +29,7 @@ module Polint
       translation = {
         flags: [],
         references: [],
+        comments: [],
         msgid: {},
         msgid_plural: {},
         msgstrs: []
@@ -38,6 +39,7 @@ module Polint
         case k
         when :flags then translation[:flags] |= v
         when :reference then translation[:references] << v
+        when :comment then translation[:comments] << v
         when :msgid, :msgid_plural then translation[k] = v
         when :msgstr then translation[:msgstrs] << v
         end

--- a/lib/polint/version.rb
+++ b/lib/polint/version.rb
@@ -1,3 +1,3 @@
 module Polint
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/data/en-valid.po
+++ b/spec/data/en-valid.po
@@ -16,3 +16,9 @@ msgid "Hello World Plural"
 msgid_plural "Hello %{n} Worlds Plural"
 msgstr[0] "Hello World Plural"
 msgstr[1] "Hello %{n} Worlds Plural"
+
+#~ msgid "Obsolete Translation"
+#~ msgstr "Obsolete Translation"
+
+#~ msgid "Another Obsolete Translation"
+#~ msgstr "Another Obsolete Translation"

--- a/spec/lib/polint/parser_spec.rb
+++ b/spec/lib/polint/parser_spec.rb
@@ -89,6 +89,15 @@ RSpec.describe Polint::Parser do
     end
   end
 
+  describe 'rule(:unparsed_comment)' do
+    let(:rule) { :unparsed_comment }
+
+    context 'when matching any comment' do
+      let(:line) { '# no semantics here' }
+      it { expect(tree).to eq comment: 'no semantics here' }
+    end
+  end
+
   describe 'rule(:msgid)' do
     let(:rule) { :msgid }
 

--- a/spec/lib/polint/parser_spec.rb
+++ b/spec/lib/polint/parser_spec.rb
@@ -92,9 +92,24 @@ RSpec.describe Polint::Parser do
   describe 'rule(:unparsed_comment)' do
     let(:rule) { :unparsed_comment }
 
-    context 'when matching any comment' do
+    context 'when matching a translator comment' do
       let(:line) { '# no semantics here' }
-      it { expect(tree).to eq comment: 'no semantics here' }
+      it { expect(tree).to eq comment: ' no semantics here' }
+    end
+
+    context 'when matching an extracted comment' do
+      let(:line) { '#. no semantics here' }
+      it { expect(tree).to eq comment: '. no semantics here' }
+    end
+
+    context 'when matching a previous translation comment' do
+      let(:line) { '#| no semantics here' }
+      it { expect(tree).to eq comment: '| no semantics here' }
+    end
+
+    context 'when matching an obsolete translation' do
+      let(:line) { '#~ obsolete things go here' }
+      it { expect{ tree }.to raise_error Parslet::ParseFailed }
     end
   end
 
@@ -260,6 +275,23 @@ RSpec.describe Polint::Parser do
             ]
           }
         ]
+      }
+    end
+  end
+
+  describe 'rule(:obsolete_translation)' do
+    let(:rule) { :obsolete_translation }
+    let(:line) { lines.join("\n") }
+
+    context 'when matching a singular single-line msgstr with comments' do
+      let(:lines) {
+        [
+          '#~ msgid "Hello World"',
+          '#~ msgstr "Hello World"'
+        ]
+      }
+      it {
+        expect(tree).to eq obsolete_translation: line
       }
     end
   end

--- a/spec/lib/polint/transform_spec.rb
+++ b/spec/lib/polint/transform_spec.rb
@@ -37,10 +37,11 @@ RSpec.describe Polint::Transform do
           { flags: [{ flag: 'fuzzy' }] },
           { reference: '../../some_file.rb:34' },
           { reference: '../../some_other_file.rb:283' },
-          { msgid: [{ quoted_string: [] }, { quoted_string: 'Hello World' }, { quoted_string: 'Hello Again'}] },
-          { msgid_plural: [{ quoted_string: [] }, { quoted_string: 'Hello %{n} Worlds' }, { quoted_string: 'Hello Again'}] },
-          { msgstr: [{ index: '0' }, { quoted_string: [] }, { quoted_string: 'Hello World' }, { quoted_string: 'Hello Again'}] },
-          { msgstr: [{ index: '1' }, { quoted_string: [] }, { quoted_string: 'Hello %{n} Worlds' }, { quoted_string: 'Hello Again'}] }
+          { comment: 'arbitrary text' },
+          { msgid: [{ quoted_string: [] }, { quoted_string: 'Hello World\\n' }, { quoted_string: 'Hello Again'}] },
+          { msgid_plural: [{ quoted_string: [] }, { quoted_string: 'Hello %{n} Worlds\\n' }, { quoted_string: 'Hello Again'}] },
+          { msgstr: [{ index: '0' }, { quoted_string: [] }, { quoted_string: 'Hello World\\n' }, { quoted_string: 'Hello Again'}] },
+          { msgstr: [{ index: '1' }, { quoted_string: [] }, { quoted_string: 'Hello %{n} Worlds\\n' }, { quoted_string: 'Hello Again'}] }
         ]
       }
     }
@@ -48,11 +49,12 @@ RSpec.describe Polint::Transform do
       expect(output).to eq translation: {
         flags: [:fuzzy],
         references: ['../../some_file.rb:34', '../../some_other_file.rb:283'],
-        msgid: { text: "\nHello World\nHello Again" },
-        msgid_plural: { text: "\nHello %{n} Worlds\nHello Again" },
+        comments: ['arbitrary text'],
+        msgid: { text: 'Hello World\\nHello Again' },
+        msgid_plural: { text: 'Hello %{n} Worlds\\nHello Again' },
         msgstrs: [
-          { index: 0, text: "\nHello World\nHello Again" },
-          { index: 1, text: "\nHello %{n} Worlds\nHello Again" }
+          { index: 0, text: 'Hello World\\nHello Again' },
+          { index: 1, text: 'Hello %{n} Worlds\\nHello Again' }
         ]
       }
     }


### PR DESCRIPTION
The parser was breaking when there were arbitrary comments, including
the kinds that aren’t parsed by this parser because we’re not
particularly interested in them, so this adds a new `unparsed_comment`
rule to handle any comment that doesn’t match an implemented.

It also now handles obsolete translations (at the end commented out with
`#~`) as even supporting arbitrary comments these were failing due to 
them not having the expected `msgid` element subsequently.

While I was in there I fixed multiline strings so they're now just joined
directly rather than having a newline inserted between them. It didn't
affect the linting but it's correct.

Also bumps the version to 0.2.1 for release.
