### PR TITLE
Handle comments on obsolete translations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    polint (0.2.1)
+    polint (0.2.2)
       parslet (~> 1.7, >= 1.7.1)
       term-ansicolor
 

--- a/lib/polint/parser.rb
+++ b/lib/polint/parser.rb
@@ -33,7 +33,7 @@ module Polint
     rule(:flag) { str(',') >> lwsp >> match(/[a-z\-]/).repeat(1).as(:flag) >> lwsp }
     rule(:flag_comment) { start_comment >> flag.repeat(1).as(:flags) >> endl }
     rule(:reference_comment) { start_comment >> str(':') >> lwsp >> match(/[^\n]/).repeat.as(:reference) >> endl }
-    rule(:unparsed_comment) { start_comment >> (match(/[^~]/) >> lwsp >> match(/[^\n]/).repeat).as(:comment) >> endl }
+    rule(:unparsed_comment) { start_comment >> match(/[^~]/) >> lwsp >> match(/[^\n]/).repeat.as(:comment) >> endl }
     rule(:comment) { flag_comment | reference_comment | unparsed_comment }
     rule(:comments) { comment.repeat }
 
@@ -47,7 +47,7 @@ module Polint
     rule(:translations) { translation.repeat }
 
     rule(:obsolete_line) { start_comment >> str('~') >> lwsp >> match(/[^\n]/).repeat >> endl }
-    rule(:obsolete_translation) { obsolete_line.repeat(1).as(:obsolete_translation) >> blank_line }
+    rule(:obsolete_translation) { (comment.repeat >> obsolete_line.repeat(1).as(:text)).as(:obsolete_translation) >> blank_line }
     rule(:obsolete_translations) { obsolete_translation.repeat }
 
     rule(:file) { (headers >> translations >> obsolete_translations).as(:file) }

--- a/lib/polint/version.rb
+++ b/lib/polint/version.rb
@@ -1,3 +1,3 @@
 module Polint
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/data/en-valid.po
+++ b/spec/data/en-valid.po
@@ -17,6 +17,7 @@ msgid_plural "Hello %{n} Worlds Plural"
 msgstr[0] "Hello World Plural"
 msgstr[1] "Hello %{n} Worlds Plural"
 
+# comment on obsolete translation
 #~ msgid "Obsolete Translation"
 #~ msgstr "Obsolete Translation"
 

--- a/spec/lib/polint/parser_spec.rb
+++ b/spec/lib/polint/parser_spec.rb
@@ -94,17 +94,17 @@ RSpec.describe Polint::Parser do
 
     context 'when matching a translator comment' do
       let(:line) { '# no semantics here' }
-      it { expect(tree).to eq comment: ' no semantics here' }
+      it { expect(tree).to eq comment: 'no semantics here' }
     end
 
     context 'when matching an extracted comment' do
       let(:line) { '#. no semantics here' }
-      it { expect(tree).to eq comment: '. no semantics here' }
+      it { expect(tree).to eq comment: 'no semantics here' }
     end
 
     context 'when matching a previous translation comment' do
       let(:line) { '#| no semantics here' }
-      it { expect(tree).to eq comment: '| no semantics here' }
+      it { expect(tree).to eq comment: 'no semantics here' }
     end
 
     context 'when matching an obsolete translation' do
@@ -286,12 +286,16 @@ RSpec.describe Polint::Parser do
     context 'when matching a singular single-line msgstr with comments' do
       let(:lines) {
         [
+          '# comment on obsolete translation',
           '#~ msgid "Hello World"',
           '#~ msgstr "Hello World"'
         ]
       }
       it {
-        expect(tree).to eq obsolete_translation: line
+        expect(tree).to eq obsolete_translation: [
+          { comment: 'comment on obsolete translation' },
+          { text: %{#~ msgid "Hello World"\n#~ msgstr "Hello World"} }
+        ]
       }
     end
   end


### PR DESCRIPTION
Also changes the way comments are parsed slightly so that leading
whitespace and semantic specifiers are ignored, which makes sense given
we’re ignoring the semantics of those specifiers anyway.
